### PR TITLE
Fix root namespace to RealityToolkit

### DIFF
--- a/Editor/UltraleapHandControllerDataProviderProfileInspector.cs
+++ b/Editor/UltraleapHandControllerDataProviderProfileInspector.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityToolkit.Editor.Extensions;
+using RealityToolkit.Editor.Profiles.InputSystem.Controllers;
+using RealityToolkit.Ultraleap.Definitions;
+using RealityToolkit.Ultraleap.InputSystem.Profiles;
 using UnityEditor;
 using UnityEngine;
-using XRTK.Editor.Extensions;
-using XRTK.Editor.Profiles.InputSystem.Controllers;
-using XRTK.Ultraleap.Definitions;
-using XRTK.Ultraleap.InputSystem.Profiles;
 
-namespace XRTK.Ultraleap.Editor.Inspectors
+namespace RealityToolkit.Ultraleap.Editor.Inspectors
 {
     /// <summary>
     /// Default inspector for the <see cref="UltraleapHandControllerDataProviderProfile"/> asset.

--- a/Editor/UltraleapPackageInstaller.cs
+++ b/Editor/UltraleapPackageInstaller.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.IO;
+using RealityToolkit.Editor;
+using RealityToolkit.Editor.Utilities;
 using UnityEditor;
-using XRTK.Editor;
-using XRTK.Editor.Utilities;
-using XRTK.Extensions;
+using RealityToolkit.Extensions;
 
-namespace XRTK.Ultraleap.Editor
+namespace RealityToolkit.Ultraleap.Editor
 {
     [InitializeOnLoad]
     internal static class UltraleapPackageInstaller

--- a/Editor/UltraleapPathFinder.cs
+++ b/Editor/UltraleapPathFinder.cs
@@ -1,10 +1,10 @@
 // Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityToolkit.Editor.Utilities;
 using UnityEngine;
-using XRTK.Editor.Utilities;
 
-namespace XRTK.Ultraleap.Editor
+namespace RealityToolkit.Ultraleap.Editor
 {
     /// <summary>
     /// Dummy scriptable object used to find the relative path of the com.xrtk.ultraleap.

--- a/Editor/UltraleapPluginUtility.cs
+++ b/Editor/UltraleapPluginUtility.cs
@@ -3,13 +3,13 @@
 
 using System.IO;
 using System.Linq;
+using RealityToolkit.Editor;
+using RealityToolkit.Editor.Utilities;
 using UnityEditor;
 using UnityEngine;
-using XRTK.Editor;
-using XRTK.Editor.Utilities;
-using XRTK.Extensions;
+using RealityToolkit.Extensions;
 
-namespace XRTK.Ultraleap.Editor
+namespace RealityToolkit.Ultraleap.Editor
 {
     [InitializeOnLoad]
     public static class UltraleapPluginUtility

--- a/Runtime/Definitions/UltraleapDeviceOffsetMode.cs
+++ b/Runtime/Definitions/UltraleapDeviceOffsetMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Ultraleap.Definitions
+namespace RealityToolkit.Ultraleap.Definitions
 {
     /// <summary>
     /// The device offset mode is only applicable for the <see cref="UltraleapOperationMode.HeadsetMounted"/>.

--- a/Runtime/Definitions/UltraleapFrameOptimizationMode.cs
+++ b/Runtime/Definitions/UltraleapFrameOptimizationMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Ultraleap.Definitions
+namespace RealityToolkit.Ultraleap.Definitions
 {
     /// <summary>
     /// When enabled, the provider will only calculate one leap frame instead of two.

--- a/Runtime/Definitions/UltraleapOperationMode.cs
+++ b/Runtime/Definitions/UltraleapOperationMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Ultraleap.Definitions
+namespace RealityToolkit.Ultraleap.Definitions
 {
     /// <summary>
     /// Supported operation modes for the Ultraleap device.

--- a/Runtime/Extensions/QuaternionExtensions.cs
+++ b/Runtime/Extensions/QuaternionExtensions.cs
@@ -4,7 +4,7 @@
 using Leap;
 using UnityEngine;
 
-namespace XRTK.Ultraleap.Extensions
+namespace RealityToolkit.Ultraleap.Extensions
 {
     /// <summary>
     /// Ultraleap platform specific <see cref="Quaternion"/> extensions.

--- a/Runtime/Extensions/TransformExtensions.cs
+++ b/Runtime/Extensions/TransformExtensions.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 using Leap;
 
-namespace XRTK.Ultraleap.Extensions
+namespace RealityToolkit.Ultraleap.Extensions
 {
     /// <summary>
     /// Ultraleap platform specific <see cref="Transform"/> extensions.

--- a/Runtime/Extensions/VectorExtensions.cs
+++ b/Runtime/Extensions/VectorExtensions.cs
@@ -4,7 +4,7 @@
 using UnityEngine;
 using Leap;
 
-namespace XRTK.Ultraleap.Extensions
+namespace RealityToolkit.Ultraleap.Extensions
 {
     /// <summary>
     /// Ultraleap platform specific <see cref="Vector3"/> extensions.

--- a/Runtime/Profiles/UltraleapHandControllerDataProviderProfile.cs
+++ b/Runtime/Profiles/UltraleapHandControllerDataProviderProfile.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityToolkit.Definitions.Controllers.Hands;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Ultraleap.Definitions;
 using UnityEngine;
-using XRTK.Definitions.Controllers.Hands;
-using XRTK.Definitions.Utilities;
-using XRTK.Ultraleap.Definitions;
 
-namespace XRTK.Ultraleap.InputSystem.Profiles
+namespace RealityToolkit.Ultraleap.InputSystem.Profiles
 {
     /// <summary>
     /// Configuration profile for the <see cref="Providers.Controllers.UltraleapHandControllerDataProvider"/> powering
-    /// the <see cref="XRTK.Providers.Controllers.Hands.MixedRealityHandController"/>.
+    /// the <see cref="RealityToolkit.Providers.Controllers.Hands.MixedRealityHandController"/>.
     /// </summary>
     [CreateAssetMenu(menuName = "Mixed Reality Toolkit/Input System/Controller Data Providers/Ultraleap Hand", fileName = "UltraleapHandControllerDataProviderProfile", order = (int)CreateProfileMenuItemIndices.Input)]
     public class UltraleapHandControllerDataProviderProfile : BaseHandControllerDataProviderProfile

--- a/Runtime/Providers/Controllers/UltraleapHandControllerDataProvider.cs
+++ b/Runtime/Providers/Controllers/UltraleapHandControllerDataProvider.cs
@@ -4,24 +4,24 @@
 using Leap;
 using System;
 using System.Collections.Generic;
+using RealityToolkit.Attributes;
+using RealityToolkit.Definitions.Controllers.Hands;
+using RealityToolkit.Definitions.Devices;
+using RealityToolkit.Definitions.InputSystem;
+using RealityToolkit.Definitions.Platforms;
+using RealityToolkit.Definitions.Utilities;
+using RealityToolkit.Interfaces.CameraSystem;
+using RealityToolkit.Interfaces.InputSystem;
+using RealityToolkit.Services;
+using RealityToolkit.Services.InputSystem.Controllers.Hands;
+using RealityToolkit.Ultraleap.Definitions;
+using RealityToolkit.Ultraleap.InputSystem.Profiles;
+using RealityToolkit.Utilities;
 using UnityEngine;
-using XRTK.Attributes;
-using XRTK.Definitions.Controllers.Hands;
-using XRTK.Definitions.Devices;
-using XRTK.Definitions.InputSystem;
-using XRTK.Definitions.Platforms;
-using XRTK.Definitions.Utilities;
-using XRTK.Extensions;
-using XRTK.Interfaces.CameraSystem;
-using XRTK.Interfaces.InputSystem;
-using XRTK.Services;
-using XRTK.Services.InputSystem.Controllers.Hands;
-using XRTK.Ultraleap.Definitions;
-using XRTK.Ultraleap.Extensions;
-using XRTK.Ultraleap.InputSystem.Profiles;
-using XRTK.Utilities;
+using RealityToolkit.Extensions;
+using RealityToolkit.Ultraleap.Extensions;
 
-namespace XRTK.Ultraleap.InputSystem.Controllers
+namespace RealityToolkit.Ultraleap.InputSystem.Controllers
 {
     /// <summary>
     /// Enables the XRTK hand tracking implementation to run powered by Ultraleap hand tracking


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Replaces the old `XRTK` root namespace with `RealityToolkit`.